### PR TITLE
chore(ci): Switch from renovate to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+    commit-message:
+      prefix: "chore(ci): "
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: daily

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.8, 3.11]
 
     steps:
     - uses: actions/checkout@v2

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,0 @@
-{
-  "extends": [
-    "config:base"
-  ]
-}


### PR DESCRIPTION
* Migrate to Dependabot given it's the GitHub native solution
* Update tested Python versions in pipelines