### PR TITLE
chore(test): cleanup mocks

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,5 +1,6 @@
 """Contains global fixtures for pytest"""
 from os import environ
+from unittest.mock import Mock, MagicMock
 
 import pytest
 import kanboard
@@ -13,30 +14,30 @@ environ['KANBOARD_CONNECT_URL'] = 'https://kanboard.example.org'
 environ['KANBOARD_API_TOKEN'] = 'l33tT0k3n'
 
 @pytest.fixture
-def kb(mocker):
+def kb():
     """
     A mock of the kanboard client.
 
     This mock is used by various tests and can be extended with more methods should they be needed.
     """
-    kb = mocker.Mock(kanboard.Client)
-    kb.add_group_member = mocker.Mock()
-    kb.create_comment = mocker.Mock()
-    kb.create_task = mocker.Mock()
-    kb.create_task_file = mocker.Mock()
-    kb.create_user = mocker.Mock()
-    kb.get_all_users = mocker.Mock()
-    kb.get_project_by_name = mocker.Mock()
-    kb.get_task = mocker.Mock()
-    kb.open_task = mocker.Mock()
-    kb.update_task = mocker.Mock()
+    kb = Mock(kanboard.Client)
+    kb.add_group_member = Mock()
+    kb.create_comment = Mock()
+    kb.create_task = Mock()
+    kb.create_task_file = Mock()
+    kb.create_user = Mock()
+    kb.get_all_users = Mock()
+    kb.get_project_by_name = Mock()
+    kb.get_task = Mock()
+    kb.open_task = Mock()
+    kb.update_task = Mock()
     return kb
 
 @pytest.fixture
-def email_message(mocker):
+def email_message():
     """
     Mock an email.message.EmailMessage object
     """
-    mail = mocker.MagicMock(EmailMessage)
+    mail = MagicMock(EmailMessage)
     mail.walk.return_value = []
     return mail

--- a/src/test_imap.py
+++ b/src/test_imap.py
@@ -1,4 +1,5 @@
 import pytest
+from unittest.mock import Mock
 
 import imaplib
 
@@ -8,7 +9,7 @@ class TestImapFunctions:
     def test_imap_connect(self, mocker):
         mocker.patch('imaplib.IMAP4_SSL')
 
-        connection = mocker.Mock()
+        connection = Mock()
         imaplib.IMAP4_SSL.return_value = connection
 
         imap_connection = imap_connect('servername', 'username', 'password')
@@ -16,16 +17,16 @@ class TestImapFunctions:
         imaplib.IMAP4_SSL.assert_called_once_with('servername')
         assert imap_connection == connection
 
-    def test_imap_close(self, mocker):
-        imap_connection = mocker.Mock()
+    def test_imap_close(self):
+        imap_connection = Mock()
 
         imap_close(imap_connection)
 
         imap_connection.close.assert_called_once()
         imap_connection.logout.assert_called_once()
 
-    def test_image_search_unseen(self, mocker):
-        imap_connection = mocker.Mock()
+    def test_image_search_unseen(self):
+        imap_connection = Mock()
         imap_connection.search.return_value = ('typ', 'data')
 
         typ, data = imap_search_unseen(imap_connection)

--- a/src/test_main.py
+++ b/src/test_main.py
@@ -1,4 +1,5 @@
 import pytest
+from unittest.mock import Mock, call
 
 import email
 import kanboard
@@ -33,7 +34,7 @@ class TestMain:
         mocker.patch("email.header.make_header")
         mocker.patch("kanboard.Client")
 
-        imap_connection = mocker.Mock()
+        imap_connection = Mock()
         imap_connection.fetch.return_value = ("typ", [(None, b"raw")])
         tasks_from_email.imap_connect.return_value = imap_connection
         tasks_from_email.imap_search_unseen.return_value = ("typ", ["a"])
@@ -70,14 +71,14 @@ class TestMain:
         imap_connection.fetch.assert_called_once_with("a", "(RFC822)")
         email.message_from_bytes.assert_called_once_with(b"raw")
         tasks_from_email.convert_to_kb_date.assert_has_calls(
-            [mocker.call("rfcdate"), mocker.call("rfcdate", 48)]
+            [call("rfcdate"), call("rfcdate", 48)]
         )
         assert email_message.__getitem__.call_args_list == [
-            mocker.call("Date"),
-            mocker.call("Date"),
-            mocker.call("From"),
-            mocker.call("To"),
-            mocker.call("Subject"),
+            call("Date"),
+            call("Date"),
+            call("From"),
+            call("To"),
+            call("Subject"),
         ]
         kanboard.Client.assert_called_once()
         tasks_from_email.create_user_for_sender.called_once_with(kb, "from@example.org")

--- a/src/test_walk_message_parts.py
+++ b/src/test_walk_message_parts.py
@@ -1,4 +1,3 @@
-
 import pytest
 
 from email import header


### PR DESCRIPTION
This refactors the parts of the tests that where using `pytest-mock` to use `unittest.mock` where it was easily possible.

`pytest-mock` is still used to mock IMAP features and in other areas where `patch` from `unittest.mock` doesn't work as a drop-in replacement.